### PR TITLE
Fixed setTimeOut for some browsers

### DIFF
--- a/live-blogging.js
+++ b/live-blogging.js
@@ -43,7 +43,7 @@ function live_blogging_poll(id)
         },
         'application/json'
     )
-    setTimeout(live_blogging_poll, 15000, id)
+    setTimeout(function(){live_blogging_poll(id)}, 15000)
 }
 
 function live_blogging_handle_entry(entry)

--- a/live-blogging.php
+++ b/live-blogging.php
@@ -716,7 +716,7 @@ function live_blogging_shortcode($atts, $id = null)
     {
         $s .= '<script type="text/javascript">
                /*<![CDATA[ */
-                setTimeout(live_blogging_poll, 15000, "' . $id . '")
+                setTimeout(function(){live_blogging_poll("'.$id .'");}, 15000)
                /*]]>*/
                </script>';
     }


### PR DESCRIPTION
On pull mode, the JS for setTimeOut fails in Chrome, Firefox and Safari.

Doing some research, it seems like the third parameter on setTimeOut is only supported on Internet Explorer and some other browsers, but it fails on a few. I edited the files to use setTimeOut in some sort on standarized way to allow a wider range of browsers. Without this update, pulling wouldn't work on my latest Chrome, Firefox or Safari.
