### PR TITLE
Unhooking of class methods

### DIFF
--- a/src/main/php/LiveBlogging/Setting/ContentHooks.php
+++ b/src/main/php/LiveBlogging/Setting/ContentHooks.php
@@ -78,9 +78,24 @@ class LiveBlogging_Setting_ContentHooks extends LiveBlogging_Setting
 		$unhooks = self::get();
 		if ( ! empty( $unhooks ) ) {
 			foreach ( $unhooks as $unhook ) {
-				if ( function_exists( $unhook ) ) {
-					remove_filter( 'the_content', $unhook );
-				}
+                $unhook = explode( ',' , $unhook, 2 );
+                $unhook = array_map( 'trim', $unhook );
+                $count = count( $unhook );
+                switch ( $count ) {
+                    case 2:
+                        if ( method_exists( $GLOBALS[$unhook[0]], $unhook[1] ) ) {
+                            remove_filter('the_content', array($GLOBALS[$unhook[0]], $unhook[1]));
+                        }
+                        break;
+
+                    case 1:
+                    default:
+                        if ( function_exists( $unhook[0] ) ) {
+                            remove_filter('the_content', $unhook[0]);
+                        }
+                        break;
+
+                }
 			}
 		}
 	}
@@ -89,9 +104,26 @@ class LiveBlogging_Setting_ContentHooks extends LiveBlogging_Setting
 		$unhooks = self::get();
 		if ( ! empty( $unhooks ) ) {
 			foreach ( $unhooks as $unhook ) {
-				if ( function_exists( $unhook ) ) {
-					add_filter( 'the_content', $unhook );
-				}
+                $unhook = explode( ',' , $unhook, 2 );
+                $unhook = array_map( 'trim', $unhook );
+                $count = count( $unhook );
+                switch( $count ) {
+                    case 2:
+                        if ( method_exists( $GLOBALS[$unhook[0]], $unhook[1]))
+                        {
+                            add_filter('the_content', array($GLOBALS[$unhook[0]], $unhook[1]));
+                        }
+                        break;
+
+                    case 1:
+                    default:
+                        if ( function_exists($unhook[0]))
+                        {
+                            add_filter('the_content', $unhook[0]);
+                        }
+                        break;
+
+                }
 			}
 		}
 	}


### PR DESCRIPTION
Enabled unhooking of content filters using class methods as per the issues previously reported in:
http://wordpress.org/support/topic/bugfix-unhooking-of-filters-not-working-for-class-methods
